### PR TITLE
feat: do not manage machinedeployment selector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -178,7 +178,8 @@ COPY --link --from=kpt-fn-sink /metalcluster_clustername.yaml ${OUT_DIR}/metalcl
 COPY --link --from=kpt-fn-sink /metalmachinetemplate_clustername-cp.yaml ${OUT_DIR}/control-plane/metalmachinetemplate.yaml
 COPY --link --from=kpt-fn-sink /taloscontrolplane_clustername-cp.yaml ${OUT_DIR}/control-plane/taloscontrolplane.yaml
 COPY --link --from=kpt-fn-sink /metalmachinetemplate_clustername-workers.yaml ${OUT_DIR}/workers/metalmachinetemplate.yaml
-COPY --link --from=kpt-fn-sink /machinedeployment_clustername-workers.yaml ${OUT_DIR}/workers/machinedeployment.yaml
+COPY --link --from=kpt-fn-sink /machinedeployment_clustername-workers.yaml /tmp/machinedeployment.yaml
+RUN kubectl patch -f /tmp/machinedeployment.yaml --local -o yaml --type=json -p '[{"op":"remove","path":"/spec/selector"}]' > "${OUT_DIR}/workers/machinedeployment.yaml"
 COPY --link --from=kpt-fn-sink /talosconfigtemplate_clustername-workers.yaml ${OUT_DIR}/workers/talosconfigtemplate.yaml
 COPY --link <<eot ${CONTROL_PLANE_ENDPOINT_FN_CONFIG}
 apiVersion: fn.kpt.dev/v1alpha1

--- a/cluster-api/v1alpha3/workload/sidero/cluster/.fn-configs/set-cluster-from-name.yaml
+++ b/cluster-api/v1alpha3/workload/sidero/cluster/.fn-configs/set-cluster-from-name.yaml
@@ -51,8 +51,6 @@ replacements:
         fieldPaths:
           - spec.clusterName
           - spec.template.spec.clusterName
-          - spec.selector.matchLabels.cluster
-          - spec.template.metadata.labels.cluster
         options:
           create: true
 

--- a/cluster-api/v1alpha3/workload/sidero/workers/machinedeployment.yaml
+++ b/cluster-api/v1alpha3/workload/sidero/workers/machinedeployment.yaml
@@ -10,8 +10,6 @@ metadata:
 spec:
   clusterName: cluster-name
   replicas: 0
-  selector:
-    matchLabels: null
   template:
     spec:
       bootstrap:
@@ -25,6 +23,3 @@ spec:
         kind: MetalMachineTemplate
         name: cluster-name-workers
       version: v1.20.15
-    metadata:
-      labels:
-        cluster: cluster-name


### PR DESCRIPTION
This field is better managed by the infrastructure controller, which
creates the Machines that are selected.
